### PR TITLE
0.0.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: pomponchik
+
+---
+
+## Short description
+
+Replace this text with a short description of the error and the behavior that you expected to see instead.
+
+
+## Describe the bug in detail
+
+Please add this test in such a way that it reproduces the bug you found and does not pass:
+
+```python
+def test_your_bug():
+    ...
+```
+
+Writing the test, please keep compatibility with the [`pytest`](https://docs.pytest.org/) framework.
+
+If for some reason you cannot describe the error in the test format, describe here the steps to reproduce it.
+
+
+## Environment
+ - OS: ...
+ - Python version (the output of the `python --version` command): ...
+ - Version of this package: ...

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,26 @@
+---
+name: Documentation fix
+about: Add something to the documentation, delete it, or change it
+title: ''
+labels: documentation
+assignees: pomponchik
+---
+
+## It's cool that you're here!
+
+Documentation is an important part of the project, we strive to make it high-quality and keep it up to date. Please adjust this template by outlining your proposal.
+
+
+## Type of action
+
+What do you want to do: remove something, add it, or change it?
+
+
+## Where?
+
+Specify which part of the documentation you want to make a change to? For example, the name of an existing documentation section or the line number in a file `README.md`.
+
+
+## The essence
+
+Please describe the essence of the proposed change

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: pomponchik
+
+---
+
+## Short description
+
+What do you propose and why do you consider it important?
+
+
+## Some details
+
+If you can, provide code examples that will show how your proposal will work. Also, if you can, indicate which alternatives to this behavior you have considered. And finally, how do you propose to test the correctness of the implementation of your idea, if at all possible?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,12 @@
+---
+name: Question or consultation
+about: Ask anything about this project
+title: ''
+labels: guestion
+assignees: pomponchik
+
+---
+
+## Your question
+
+Here you can freely describe your question about the project. Please, before doing this, read the documentation provided, and ask the question only if the necessary answer is not there. In addition, please keep in mind that this is a free non-commercial project and user support is optional for its author. The response time is not guaranteed in any way.

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -32,7 +32,7 @@ jobs:
       run: pip list
 
     - name: Run tests and show coverage on the command line
-      run: coverage run --source=suby --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m
+      run: coverage run --source=suby --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100
 
     - name: Upload reports to codecov
       env:
@@ -45,4 +45,4 @@ jobs:
         ./codecov -t ${CODECOV_TOKEN}
 
     - name: Run tests and show the branch coverage on the command line
-      run: coverage run --source=suby --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m
+      run: coverage run --branch --source=suby --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100

--- a/.github/workflows/tests_and_coverage_old.yml
+++ b/.github/workflows/tests_and_coverage_old.yml
@@ -32,7 +32,7 @@ jobs:
       run: pip list
 
     - name: Run tests and show coverage on the command line
-      run: coverage run --source=suby --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m
+      run: coverage run --source=suby --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100
 
     - name: Upload reports to codecov
       env:
@@ -45,4 +45,4 @@ jobs:
         ./codecov -t ${CODECOV_TOKEN}
 
     - name: Run tests and show the branch coverage on the command line
-      run: coverage run --source=suby --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m
+      run: coverage run --branch --source=suby --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100

--- a/README.md
+++ b/README.md
@@ -52,7 +52,21 @@ suby('python', '-c', 'print("hello, world!")')
 
 ## Run subprocess and look at the result
 
-The `suby` function returns an object of the `SubprocessResult` class. It contains the following required fields:
+The `suby` module is a callable object and can be imported like this:
+
+```python
+import suby
+```
+
+If you use static type checking and get an error that it is impossible to call the module, use a more detailed import form:
+
+```python
+from suby import suby
+```
+
+Functionally, these two import ways are identical.
+
+When called `suby` returns an object of the `SubprocessResult` class. It contains the following required fields:
 
 - **id** - a unique string that allows you to distinguish one result of calling the same command from another.
 - **stdout** - a string containing the entire buffered output of the command being run.
@@ -63,14 +77,14 @@ The `suby` function returns an object of the `SubprocessResult` class. It contai
 The simplest example of what it might look like:
 
 ```python
-import suby
-
 result = suby('python', '-c', 'print("hello, world!")')
 print(result)
 # > SubprocessResult(id='e9f2d29acb4011ee8957320319d7541c', stdout='hello, world!\n', stderr='', returncode=0, killed_by_token=False)
 ```
 
 You can use strings or [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) objects as positional arguments for `suby`.
+
+
 
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -58,23 +58,13 @@ The `suby` module is a callable object and can be imported like this:
 import suby
 ```
 
-If you use static type checking and get an error that it is impossible to call the module, use a more detailed import form:
+If you use static type checking and get an error that it is impossible to call the module, use a more detailed import form - functionally, these two import ways are identical:
 
 ```python
 from suby import suby
 ```
 
-Functionally, these two import ways are identical.
-
-When called `suby` returns an object of the `SubprocessResult` class. It contains the following required fields:
-
-- **id** - a unique string that allows you to distinguish one result of calling the same command from another.
-- **stdout** - a string containing the entire buffered output of the command being run.
-- **stderr** - a string containing the entire buffered stderr of the command being run.
-- **returncode** - an integer indicating the return code of the subprocess. `0` means that the process was completed successfully, the other options usually indicate something bad.
-- **killed_by_token** - a boolean flag indicating whether the subprocess was killed due to [token](https://cantok.readthedocs.io/en/latest/the_pattern/) cancellation.
-
-The simplest example of what it might look like:
+Let's try to call `suby`. You can use strings or [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) objects as positional arguments, but now we call it with only simple strings:
 
 ```python
 result = suby('python', '-c', 'print("hello, world!")')
@@ -82,7 +72,13 @@ print(result)
 # > SubprocessResult(id='e9f2d29acb4011ee8957320319d7541c', stdout='hello, world!\n', stderr='', returncode=0, killed_by_token=False)
 ```
 
-You can use strings or [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) objects as positional arguments for `suby`.
+We can see that it returns an object of the `SubprocessResult` class. It contains the following required fields:
+
+- **id** - a unique string that allows you to distinguish one result of calling the same command from another.
+- **stdout** - a string containing the entire buffered output of the command being run.
+- **stderr** - a string containing the entire buffered stderr of the command being run.
+- **returncode** - an integer indicating the return code of the subprocess. `0` means that the process was completed successfully, the other options usually indicate something bad.
+- **killed_by_token** - a boolean flag indicating whether the subprocess was killed due to [token](https://cantok.readthedocs.io/en/latest/the_pattern/) cancellation.
 
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ print(result)
 You can use strings or [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) objects as positional arguments for `suby`.
 
 
-
-
 ## Output
 
 By default, the `stdout` and `stderr` of the subprocess are forwarded to the `stdout` and `stderr` of the current process. The reading from the subprocess is continuous, and the output is every time a full line is read. For continuous reading from `stderr`, a separate thread is created in the main process, so that `stdout` and `stderr` are read independently.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     'emptylog>=0.0.7',
-    'cantok>=0.0.18',
+    'cantok>=0.0.23',
 ]
 classifiers = [
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     'emptylog>=0.0.7',
-    'cantok>=0.0.23',
+    'cantok>=0.0.24',
 ]
 classifiers = [
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ classifiers = [
     'Intended Audience :: Developers',
     'Topic :: Software Development :: Libraries',
 ]
+keywords = [
+    'subprocesses',
+    'subprocesses wrapper',
+    'execute commands',
+]
 
 [tool.setuptools.package-data]
 "suby" = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "suby"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   { name="Evgeniy Blinov", email="zheni-b@yandex.ru" },
 ]

--- a/suby/proxy_module.py
+++ b/suby/proxy_module.py
@@ -28,7 +28,7 @@ class ProxyModule(sys.modules[__name__].__class__):  # type: ignore[misc]
         """
         About reading from strout and stderr: https://stackoverflow.com/a/28319191/14522393
         """
-        if timeout is not None and token is None:
+        if timeout is not None and isinstance(token, DefaultToken):
             token = TimeoutToken(timeout)
         elif timeout is not None:
             token += TimeoutToken(timeout)  # type: ignore[operator]

--- a/suby/proxy_module.py
+++ b/suby/proxy_module.py
@@ -31,7 +31,7 @@ class ProxyModule(sys.modules[__name__].__class__):  # type: ignore[misc]
         if timeout is not None and isinstance(token, DefaultToken):
             token = TimeoutToken(timeout)
         elif timeout is not None:
-            token += TimeoutToken(timeout)  # type: ignore[operator]
+            token += TimeoutToken(timeout)
 
         converted_arguments = self.convert_arguments(arguments)
         arguments_string_representation = ' '.join([argument if ' ' not in argument else f'"{argument}"' for argument in converted_arguments])
@@ -63,7 +63,7 @@ class ProxyModule(sys.modules[__name__].__class__):  # type: ignore[misc]
                 if result.killed_by_token:
                     logger.error(f'The execution of the "{arguments_string_representation}" command was canceled using a cancellation token.')
                     try:
-                        token.check()  # type: ignore[union-attr]
+                        token.check()
                     except CancellationError as e:
                         e.result = result  # type: ignore[attr-defined]
                         raise e

--- a/suby/proxy_module.py
+++ b/suby/proxy_module.py
@@ -4,6 +4,7 @@ from threading import Thread
 from subprocess import Popen, PIPE
 from typing import List, Tuple, Callable, Union, Optional, Any
 from pathlib import Path
+from types import ModuleType
 
 from emptylog import EmptyLogger, LoggerProtocol
 from cantok import AbstractToken, TimeoutToken, DefaultToken, CancellationError
@@ -129,3 +130,7 @@ class ProxyModule(sys.modules[__name__].__class__):  # type: ignore[misc]
         result.stdout = ''.join(stdout_buffer)
         result.stderr = ''.join(stderr_buffer)
         result.returncode = returncode
+
+    @property
+    def suby(self) -> ModuleType:
+        return self

--- a/tests/test_proxy_module.py
+++ b/tests/test_proxy_module.py
@@ -331,3 +331,7 @@ def test_use_path_object_as_first_positional_argument():
     assert result.stdout == 'kek\n'
     assert result.stderr == ''
     assert result.returncode == 0
+
+
+def test_suby_as_attribute_of_suby():
+    assert suby.suby is suby

--- a/tests/test_proxy_module.py
+++ b/tests/test_proxy_module.py
@@ -335,3 +335,9 @@ def test_use_path_object_as_first_positional_argument():
 
 def test_suby_as_attribute_of_suby():
     assert suby.suby is suby
+
+
+def test_full_import_form():
+    from suby import suby as local_suby
+
+    assert suby is local_suby


### PR DESCRIPTION
A little update.

- Added a 100% test coverage gate.
- Added new issue templates.
- Changed the internal implementation of working with cancellation tokens: added `DefaultToken` support.
- Added some keywords to the package metadata.
- Now you can import `suby` both by expressions like `import suby` and `from suby import suby`. It's useful if you're using some type checking tools.