### PR TITLE
0.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,14 +235,14 @@ run('python -c "print(\'hello, world!\')"', stdout_callback=my_new_stdout)
 # You can't see it here, but if you run this code yourself, the output in the console will be red!
 ```
 
-You can also completely disable the output by passing `True` as the `catch_output` parameter:
+You can also disable the default forwarding to the current process by passing `True` as the `catch_output` parameter:
 
 ```python
 run('python -c "print(\'hello, world!\')"', catch_output=True)
 # There's nothing here.
 ```
 
-If you specify `catch_output=True`, even if you have also defined custom callback functions, they will not be called. In addition, `suby` always returns [the result](#run-subprocess-and-look-at-the-result) of executing the command, containing the full output. The `catch_output` argument can suppress only the output, but it does not prevent the buffering of output.
+If you specify `catch_output=True`, the default `stdout` and `stderr` forwarding callbacks are suppressed, so subprocess output is not printed by `suby` automatically. Custom `stdout_callback` and `stderr_callback` functions are still called for each line. In addition, `suby` always returns [the result](#run-subprocess-and-look-at-the-result) of executing the command, containing the full output. The `catch_output` argument can suppress only the default console forwarding, but it does not prevent custom callback delivery or result buffering.
 
 <details>
   <summary>Notes about concurrent output</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.8"
 dependencies = [
     'emptylog>=0.0.12',
     'cantok>=0.0.36',
-    'microbenchmark>=0.0.2',
+    'microbenchmark>=0.0.3',
     'sigmatch>=0.0.9',
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     'emptylog>=0.0.12',
     'cantok>=0.0.36',
     'microbenchmark>=0.0.2',
+    'sigmatch>=0.0.9',
 ]
 classifiers = [
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "suby"
-version = "0.0.7"
+version = "0.0.8"
 authors = [
   { name="Evgeniy Blinov", email="zheni-b@yandex.ru" },
 ]

--- a/suby/run.py
+++ b/suby/run.py
@@ -273,7 +273,7 @@ def split_argument(argument: str, double_backslash: bool) -> List[str]:
 def check_output_stream_callback(parameter_name: str, callback: Any) -> None:  # type: ignore[misc]
     def build_message(reason: str) -> str:
         return (
-            f'{parameter_name} must be a synchronous, non-generator callable that can be invoked as callback(line), '  # type: ignore[misc]
+            f'{parameter_name} must be a synchronous, non-generator callable that can be invoked as callback(line), '  # type: ignore[misc, unused-ignore]
             f'where line is a str output line; got {callback!r} ({type(callback).__name__}). {reason}'  # type: ignore[misc]
         )
 

--- a/suby/run.py
+++ b/suby/run.py
@@ -4,6 +4,13 @@ import os
 import stat
 from collections.abc import Mapping as RuntimeMapping
 from dataclasses import dataclass, field
+from functools import partial
+from inspect import (
+    isasyncgenfunction,
+    isclass,
+    iscoroutinefunction,
+    isgeneratorfunction,
+)
 from math import isfinite
 from pathlib import Path
 from platform import system
@@ -35,6 +42,7 @@ from cantok import (
 from cantok import ConditionCancellationError as CantokConditionCancellationError
 from cantok import TimeoutCancellationError as CantokTimeoutCancellationError
 from emptylog import EmptyLogger, LoggerProtocol
+from sigmatch import PossibleCallMatcher, SignatureMismatchError
 
 from suby.callbacks import stderr_with_flush, stdout_with_flush
 from suby.errors import (
@@ -49,6 +57,7 @@ from suby.process_waiting import has_event_driven_wait, wait_for_process_exit
 from suby.subprocess_result import SubprocessResult
 
 StreamCallback = Callable[[str], Any]  # type: ignore[misc, unused-ignore]
+STREAM_CALLBACK_MATCHER = PossibleCallMatcher('.')
 _CUSTOM_TOKEN_POLL_TIMEOUT_SECONDS = 0.0001
 _CANCELLATION_ERROR_TYPES: Mapping[Type[CancellationError], Type[CancellationError]] = {
     CantokConditionCancellationError: ConditionCancellationError,
@@ -142,6 +151,9 @@ def run(  # noqa: PLR0913, PLR0915
         popen_kwargs['env'] = subprocess_env
     if subprocess_directory is not None:
         popen_kwargs['cwd'] = subprocess_directory
+
+    check_output_stream_callback('stdout_callback', stdout_callback)
+    check_output_stream_callback('stderr_callback', stderr_callback)
 
     state = _ExecutionState()
 
@@ -256,6 +268,41 @@ def split_argument(argument: str, double_backslash: bool) -> List[str]:
     if double_backslash:
         argument = argument.replace('\\', '\\\\')
     return shlex_split(argument)
+
+
+def check_output_stream_callback(parameter_name: str, callback: StreamCallback) -> None:
+    def build_message(reason: str) -> str:
+        return (
+            f'{parameter_name} must be a synchronous, non-generator callable that can be invoked as callback(line), '
+            f'where line is a str output line; got {callback!r} ({type(callback).__name__}). {reason}'
+        )
+
+    if not callable(callback):
+        raise SignatureMismatchError(build_message('The value is not callable.'))
+
+    inspected_callback = callback
+    while isinstance(inspected_callback, partial):
+        inspected_callback = inspected_callback.func
+
+    if isclass(inspected_callback):
+        raise SignatureMismatchError(build_message('callback classes are not supported; pass a function or a callable instance instead.'))
+
+    try:
+        inspected_call = object.__getattribute__(inspected_callback, '__call__')
+    except AttributeError:
+        inspected_call = None
+    for inspected in (inspected_callback, inspected_call):
+        if inspected is None:
+            continue
+        if iscoroutinefunction(inspected):
+            raise SignatureMismatchError(build_message('async callbacks are not supported because suby invokes stream callbacks synchronously.'))
+        if isasyncgenfunction(inspected):
+            raise SignatureMismatchError(build_message('async generator callbacks are not supported because suby invokes stream callbacks synchronously and ignores callback return values.'))
+        if isgeneratorfunction(inspected):
+            raise SignatureMismatchError(build_message('generator callbacks are not supported because suby invokes stream callbacks synchronously and ignores callback return values.'))
+
+    if not STREAM_CALLBACK_MATCHER.match(callback, raise_exception=False):
+        raise SignatureMismatchError(build_message('The callable signature does not accept one positional output line.'))
 
 
 def prepare_directory(directory: Optional[Union[str, Path]]) -> Optional[str]:
@@ -502,12 +549,18 @@ def read_stream(  # noqa: PLR0913
             if state.failure_state.error is not None:
                 return
             buffer.append(line)
-            if not catch_output:
+            if should_call_stream_callback(catch_output, callback):
                 callback(line)
         except Exception as error:  # noqa: BLE001
             if state.failure_state.set(error):
                 state.wake_event.set()
             return
+
+
+def should_call_stream_callback(catch_output: bool, callback: StreamCallback) -> bool:
+    if not catch_output:
+        return True
+    return callback not in (stdout_with_flush, stderr_with_flush)
 
 
 def wait_for_process_exit_and_signal(process: Popen[str], state: _ExecutionState) -> None:

--- a/suby/run.py
+++ b/suby/run.py
@@ -274,7 +274,7 @@ def check_output_stream_callback(parameter_name: str, callback: Any) -> None:  #
     def build_message(reason: str) -> str:
         return (
             f'{parameter_name} must be a synchronous, non-generator callable that can be invoked as callback(line), '  # type: ignore[misc, unused-ignore]
-            f'where line is a str output line; got {callback!r} ({type(callback).__name__}). {reason}'  # type: ignore[misc]
+            f'where line is a str output line; got {callback!r} ({type(callback).__name__}). {reason}'  # type: ignore[misc, unused-ignore]
         )
 
     if not callable(callback):  # type: ignore[misc]

--- a/suby/run.py
+++ b/suby/run.py
@@ -270,38 +270,39 @@ def split_argument(argument: str, double_backslash: bool) -> List[str]:
     return shlex_split(argument)
 
 
-def check_output_stream_callback(parameter_name: str, callback: StreamCallback) -> None:
+def check_output_stream_callback(parameter_name: str, callback: Any) -> None:  # type: ignore[misc]
     def build_message(reason: str) -> str:
         return (
-            f'{parameter_name} must be a synchronous, non-generator callable that can be invoked as callback(line), '
-            f'where line is a str output line; got {callback!r} ({type(callback).__name__}). {reason}'
+            f'{parameter_name} must be a synchronous, non-generator callable that can be invoked as callback(line), '  # type: ignore[misc]
+            f'where line is a str output line; got {callback!r} ({type(callback).__name__}). {reason}'  # type: ignore[misc]
         )
 
-    if not callable(callback):
+    if not callable(callback):  # type: ignore[misc]
         raise SignatureMismatchError(build_message('The value is not callable.'))
 
-    inspected_callback = callback
-    while isinstance(inspected_callback, partial):
-        inspected_callback = inspected_callback.func
+    inspected_callback = callback  # type: ignore[misc]
+    partial_type: type[object] = type(partial(len))
+    while isinstance(inspected_callback, partial_type):  # type: ignore[misc]
+        inspected_callback = object.__getattribute__(inspected_callback, 'func')  # type: ignore[misc]
 
-    if isclass(inspected_callback):
+    if isclass(inspected_callback):  # type: ignore[misc]
         raise SignatureMismatchError(build_message('callback classes are not supported; pass a function or a callable instance instead.'))
 
     try:
-        inspected_call = object.__getattribute__(inspected_callback, '__call__')
+        inspected_call = object.__getattribute__(inspected_callback, '__call__')  # type: ignore[misc]
     except AttributeError:
         inspected_call = None
-    for inspected in (inspected_callback, inspected_call):
-        if inspected is None:
+    for inspected in (inspected_callback, inspected_call):  # type: ignore[misc]
+        if inspected is None:  # type: ignore[misc]
             continue
-        if iscoroutinefunction(inspected):
+        if iscoroutinefunction(inspected):  # type: ignore[misc]
             raise SignatureMismatchError(build_message('async callbacks are not supported because suby invokes stream callbacks synchronously.'))
-        if isasyncgenfunction(inspected):
+        if isasyncgenfunction(inspected):  # type: ignore[misc]
             raise SignatureMismatchError(build_message('async generator callbacks are not supported because suby invokes stream callbacks synchronously and ignores callback return values.'))
-        if isgeneratorfunction(inspected):
+        if isgeneratorfunction(inspected):  # type: ignore[misc]
             raise SignatureMismatchError(build_message('generator callbacks are not supported because suby invokes stream callbacks synchronously and ignores callback return values.'))
 
-    if not STREAM_CALLBACK_MATCHER.match(callback, raise_exception=False):
+    if not STREAM_CALLBACK_MATCHER.match(callback, raise_exception=False):  # type: ignore[misc]
         raise SignatureMismatchError(build_message('The callable signature does not accept one positional output line.'))
 
 

--- a/tests/documentation/test_readme.py
+++ b/tests/documentation/test_readme.py
@@ -145,6 +145,21 @@ def test_catch_output_suppresses_console_output():
     assert result.stdout == 'hello, world!\n'
 
 
+def test_catch_output_keeps_custom_callbacks():
+    """catch_output=True suppresses default console forwarding without bypassing custom callbacks."""
+    collected = []
+    stderr_buffer = StringIO()
+    stdout_buffer = StringIO()
+
+    with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
+        result = run('python -c "print(\'hello, world!\')"', catch_output=True, stdout_callback=collected.append)
+
+    assert collected == ['hello, world!\n']
+    assert stdout_buffer.getvalue() == ''
+    assert stderr_buffer.getvalue() == ''
+    assert result.stdout == 'hello, world!\n'
+
+
 @pytest.mark.parametrize(
     ('command', 'run_kwargs', 'expected_info', 'expected_error'),
     [

--- a/tests/typing/test_typing_run.py
+++ b/tests/typing/test_typing_run.py
@@ -260,14 +260,36 @@ def test_run_rejects_callbacks_with_invalid_signatures() -> None:
     def callback_with_bytes_input(line: bytes) -> None:
         pass
 
+    class CallableCallbackWithoutArguments:
+        def __call__(self) -> None:
+            pass
+
+    class CallableCallbackWithExtraArgument:
+        def __call__(self, line: str, extra: int) -> None:
+            pass
+
+    class CallableCallbackWithBytesInput:
+        def __call__(self, line: bytes) -> None:
+            pass
+
     run('python -c pass', stdout_callback=callback_without_arguments)  # E: [arg-type]
     run('python -c pass', stderr_callback=callback_without_arguments)  # E: [arg-type]
     run('python -c pass', stdout_callback=callback_with_extra_argument)  # E: [arg-type]
     run('python -c pass', stderr_callback=callback_with_extra_argument)  # E: [arg-type]
     run('python -c pass', stdout_callback=callback_with_bytes_input)  # E: [arg-type]
     run('python -c pass', stderr_callback=callback_with_bytes_input)  # E: [arg-type]
+    run('python -c pass', stdout_callback=CallableCallbackWithoutArguments().__call__)  # E: [arg-type]
+    run('python -c pass', stderr_callback=CallableCallbackWithoutArguments().__call__)  # E: [arg-type]
+    run('python -c pass', stdout_callback=CallableCallbackWithExtraArgument().__call__)  # E: [arg-type]
+    run('python -c pass', stderr_callback=CallableCallbackWithExtraArgument().__call__)  # E: [arg-type]
+    run('python -c pass', stdout_callback=CallableCallbackWithBytesInput().__call__)  # E: [arg-type]
+    run('python -c pass', stderr_callback=CallableCallbackWithBytesInput().__call__)  # E: [arg-type]
     run('python -c pass', stdout_callback=None)  # E: [arg-type]
+    run('python -c pass', stderr_callback=None)  # E: [arg-type]
+    run('python -c pass', stdout_callback=123)  # E: [arg-type]
     run('python -c pass', stderr_callback=123)  # E: [arg-type]
+    run('python -c pass', stdout_callback=object())  # E: [arg-type]
+    run('python -c pass', stderr_callback=object())  # E: [arg-type]
 
 
 @pytest.mark.mypy_testing
@@ -472,13 +494,22 @@ def test_run_static_return_type_is_not_changed_by_catch_exceptions() -> None:
 
 @pytest.mark.mypy_testing
 def test_run_known_typing_gaps_are_currently_accepted() -> None:
-    """Current known gaps: mypy still accepts run() with no command args, timeout=True, and async callbacks."""
+    """Current known gaps: mypy still accepts cases that runtime validation rejects."""
     async def async_callback(line: str) -> None:
         pass
+
+    def generator_callback(line: str):
+        yield line
+
+    class CallbackClass:
+        def __init__(self, line: str) -> None:
+            pass
 
     run()
     run('python -c pass', timeout=True)
     run('python -c pass', stdout_callback=async_callback)
+    run('python -c pass', stderr_callback=generator_callback)
+    run('python -c pass', stdout_callback=CallbackClass)
 
 
 @pytest.mark.mypy_testing

--- a/tests/units/test_run.py
+++ b/tests/units/test_run.py
@@ -8,6 +8,7 @@ import sys
 import time
 from collections import OrderedDict, UserDict
 from contextlib import redirect_stderr, redirect_stdout
+from functools import partial
 from io import StringIO
 from os import environ
 from pathlib import Path, PurePath
@@ -29,6 +30,7 @@ from cantok import (
 )
 from emptylog import MemoryLogger
 from full_match import match
+from sigmatch import SignatureMismatchError
 
 import suby
 from suby import (
@@ -2432,9 +2434,177 @@ def test_callback_that_prints_does_not_deadlock():
     ],
 )
 def test_callbacks_must_be_callable(run_kwargs, command):
-    """stdout_callback and stderr_callback must be callable objects, otherwise run() raises TypeError."""
-    with pytest.raises(TypeError):
+    """stdout_callback and stderr_callback must be callable objects, otherwise run() raises SignatureMismatchError."""
+    with pytest.raises(SignatureMismatchError, match='callback\\(line\\)'):
         run(sys.executable, '-c', command, split=False, **run_kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ('parameter_name', 'callback_factory'),
+    [
+        pytest.param('stdout_callback', lambda: _valid_one_required_callback, id='stdout one required line'),
+        pytest.param('stderr_callback', lambda: _valid_one_required_callback, id='stderr one required line'),
+        pytest.param('stdout_callback', lambda: _valid_optional_line_callback, id='stdout optional line'),
+        pytest.param('stderr_callback', lambda: _valid_optional_line_callback, id='stderr optional line'),
+        pytest.param('stdout_callback', lambda: _valid_optional_positional_callback, id='stdout optional positional'),
+        pytest.param('stderr_callback', lambda: _valid_optional_positional_callback, id='stderr optional positional'),
+        pytest.param('stdout_callback', lambda: _valid_optional_keyword_only_callback, id='stdout optional keyword-only'),
+        pytest.param('stderr_callback', lambda: _valid_optional_keyword_only_callback, id='stderr optional keyword-only'),
+        pytest.param('stdout_callback', lambda: _valid_varargs_callback, id='stdout varargs'),
+        pytest.param('stderr_callback', lambda: _valid_varargs_callback, id='stderr varargs'),
+        pytest.param('stdout_callback', lambda: _positional_only_callback, id='stdout positional-only'),
+        pytest.param('stderr_callback', lambda: _positional_only_callback, id='stderr positional-only'),
+        pytest.param('stdout_callback', lambda: _CallableCallback(), id='stdout callable instance'),
+        pytest.param('stderr_callback', lambda: _CallableCallback(), id='stderr callable instance'),
+        pytest.param('stdout_callback', lambda: partial(_callback_target_with_one_slot), id='stdout partial unchanged'),
+        pytest.param('stderr_callback', lambda: partial(_callback_target_with_one_slot), id='stderr partial unchanged'),
+        pytest.param('stdout_callback', lambda: partial(_callback_target_with_optional_extra, extra='fixed'), id='stdout partial keyword'),
+        pytest.param('stderr_callback', lambda: partial(_callback_target_with_optional_extra, extra='fixed'), id='stderr partial keyword'),
+        pytest.param('stdout_callback', lambda: partial(_callback_target_with_two_slots, 'fixed'), id='stdout partial leaves slot'),
+        pytest.param('stderr_callback', lambda: partial(_callback_target_with_two_slots, 'fixed'), id='stderr partial leaves slot'),
+    ],
+)
+def test_check_output_stream_callback_accepts_valid_callbacks(parameter_name, callback_factory):
+    """Runtime callback validation accepts callables that can be invoked as callback(line)."""
+    _run_module.check_output_stream_callback(parameter_name, callback_factory())
+
+
+def _positional_only_callback(line, /):
+    _ = line
+
+
+def _valid_one_required_callback(line):
+    return line
+
+
+def _valid_optional_line_callback(line='fallback'):
+    return line
+
+
+def _valid_optional_positional_callback(line, extra='fallback'):
+    return line, extra
+
+
+def _valid_optional_keyword_only_callback(line, *, extra='fallback'):
+    return line, extra
+
+
+def _valid_varargs_callback(*lines):
+    return lines
+
+
+class _CallableCallback:
+    def __call__(self, line):
+        _ = line
+
+
+class _CallableCallbackClass:
+    def __init__(self, line):
+        self.line = line
+
+
+def _callback_target_with_one_slot(line):
+    _ = line
+
+
+def _callback_target_with_optional_extra(line, extra=None):
+    _ = line, extra
+
+
+def _callback_target_with_two_slots(_fixed, line):
+    _ = line
+
+
+@pytest.mark.parametrize(
+    ('parameter_name', 'callback_factory', 'message_fragment'),
+    [
+        pytest.param('stdout_callback', lambda: None, 'stdout_callback', id='stdout none'),
+        pytest.param('stderr_callback', lambda: 123, 'stderr_callback', id='stderr int'),
+        pytest.param('stdout_callback', lambda: (lambda: None), 'stdout_callback', id='stdout no args'),
+        pytest.param('stderr_callback', lambda: (lambda: None), 'stderr_callback', id='stderr no args'),
+        pytest.param('stdout_callback', lambda: _invalid_required_extra_callback, 'stdout_callback', id='stdout required extra positional'),
+        pytest.param('stderr_callback', lambda: _invalid_required_extra_callback, 'stderr_callback', id='stderr required extra positional'),
+        pytest.param('stdout_callback', lambda: _invalid_keyword_only_line_callback, 'stdout_callback', id='stdout keyword-only line'),
+        pytest.param('stderr_callback', lambda: _invalid_keyword_only_line_callback, 'stderr_callback', id='stderr keyword-only line'),
+        pytest.param('stdout_callback', lambda: _invalid_required_keyword_only_callback, 'stdout_callback', id='stdout required keyword-only'),
+        pytest.param('stderr_callback', lambda: _invalid_required_keyword_only_callback, 'stderr_callback', id='stderr required keyword-only'),
+        pytest.param('stdout_callback', lambda: _InvalidCallableCallback(), 'stdout_callback', id='stdout invalid callable instance'),
+        pytest.param('stderr_callback', lambda: _InvalidCallableCallback(), 'stderr_callback', id='stderr invalid callable instance'),
+        pytest.param('stdout_callback', lambda: _CallableCallbackClass, 'callback classes are not supported', id='stdout callback class'),
+        pytest.param('stderr_callback', lambda: _CallableCallbackClass, 'callback classes are not supported', id='stderr callback class'),
+        pytest.param('stdout_callback', lambda: _InvalidCallableCallbackClass, 'callback classes are not supported', id='stdout invalid callback class'),
+        pytest.param('stderr_callback', lambda: _InvalidCallableCallbackClass, 'callback classes are not supported', id='stderr invalid callback class'),
+        pytest.param('stdout_callback', lambda: partial(_CallableCallbackClass), 'callback classes are not supported', id='stdout partial callback class'),
+        pytest.param('stderr_callback', lambda: partial(_CallableCallbackClass), 'callback classes are not supported', id='stderr partial callback class'),
+        pytest.param('stdout_callback', lambda: _async_callback, 'async callbacks are not supported', id='stdout async function'),
+        pytest.param('stderr_callback', lambda: partial(_async_callback), 'async callbacks are not supported', id='stderr async partial'),
+        pytest.param('stdout_callback', lambda: partial(partial(_async_callback)), 'async callbacks are not supported', id='stdout nested async partial'),
+        pytest.param('stderr_callback', lambda: partial(_async_callback_with_optional_extra, extra='fixed'), 'async callbacks are not supported', id='stderr async keyword partial'),
+        pytest.param('stdout_callback', lambda: _AsyncCallableCallback(), 'async callbacks are not supported', id='stdout async callable instance'),
+        pytest.param('stderr_callback', lambda: partial(_AsyncCallableCallback()), 'async callbacks are not supported', id='stderr async callable partial'),
+        pytest.param('stdout_callback', lambda: _async_generator_callback, 'generator callbacks are not supported', id='stdout async generator function'),
+        pytest.param('stderr_callback', lambda: _generator_callback, 'generator callbacks are not supported', id='stderr generator function'),
+        pytest.param('stdout_callback', lambda: _GeneratorCallableCallback(), 'generator callbacks are not supported', id='stdout generator callable instance'),
+        pytest.param('stderr_callback', lambda: partial(_generator_callback), 'generator callbacks are not supported', id='stderr generator partial'),
+        pytest.param('stdout_callback', lambda: partial(_callback_target_with_one_slot, 'already-bound'), 'stdout_callback', id='stdout partial no slots'),
+        pytest.param('stderr_callback', lambda: partial(_callback_target_with_one_slot, 'already-bound'), 'stderr_callback', id='stderr partial no slots'),
+    ],
+)
+def test_check_output_stream_callback_rejects_invalid_callbacks(parameter_name, callback_factory, message_fragment):
+    """Runtime callback validation rejects values that cannot be safely used by stream readers."""
+    with pytest.raises(SignatureMismatchError, match=re.escape(message_fragment)) as exc_info:
+        _run_module.check_output_stream_callback(parameter_name, callback_factory())
+
+    assert parameter_name in str(exc_info.value)
+    assert 'callback(line)' in str(exc_info.value)
+
+
+class _InvalidCallableCallback:
+    def __call__(self):
+        return None
+
+
+def _invalid_required_extra_callback(line, extra):
+    return line, extra
+
+
+def _invalid_keyword_only_line_callback(*, line):
+    return line
+
+
+def _invalid_required_keyword_only_callback(line, *, required):
+    return line, required
+
+
+class _InvalidCallableCallbackClass:
+    def __init__(self):
+        pass
+
+
+async def _async_callback(line):
+    _ = line
+
+
+async def _async_callback_with_optional_extra(line, extra=None):
+    _ = line, extra
+
+
+class _AsyncCallableCallback:
+    async def __call__(self, line):
+        _ = line
+
+
+async def _async_generator_callback(line):
+    yield line
+
+
+def _generator_callback(line):
+    yield line
+
+
+class _GeneratorCallableCallback:
+    def __call__(self, line):
+        yield line
 
 
 @pytest.mark.parametrize(
@@ -2454,34 +2624,83 @@ def test_callbacks_must_be_callable(run_kwargs, command):
         ),
     ],
 )
-def test_catch_output_true_bypasses_callbacks_entirely(
+def test_catch_output_true_calls_custom_callbacks_without_console_forwarding(
     callback_kwarg,
     command,
     expected_stdout,
     expected_stderr,
     assert_no_suby_thread_leaks,
 ):
-    """With catch_output=True, custom callbacks are bypassed entirely and output is only stored in the result."""
+    """catch_output=True suppresses default printing but still delivers lines to custom callbacks."""
     seen: List[str] = []
+    stdout_buffer = StringIO()
+    stderr_buffer = StringIO()
 
-    def callback(text: str) -> None:
-        seen.append(text)
-        raise RuntimeError('callback should not be called')
-
-    with assert_no_suby_thread_leaks():
+    with assert_no_suby_thread_leaks(), redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
         result = run(
             sys.executable,
             '-c',
             command,
             split=False,
             catch_output=True,
-            catch_exceptions=True,
-            **{callback_kwarg: callback},
+            **{callback_kwarg: seen.append},
         )
 
-    assert seen == []
+    assert seen == [expected_stdout or expected_stderr]
+    assert stdout_buffer.getvalue() == ''
+    assert stderr_buffer.getvalue() == ''
     assert result.stdout == expected_stdout
     assert result.stderr == expected_stderr
+
+
+def test_catch_output_true_calls_both_custom_callbacks_without_console_forwarding(assert_no_suby_thread_leaks):
+    """Both custom stream callbacks still run in capture mode while result buffering remains intact."""
+    stdout_lines: List[str] = []
+    stderr_lines: List[str] = []
+    stdout_buffer = StringIO()
+    stderr_buffer = StringIO()
+
+    with assert_no_suby_thread_leaks(), redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
+        result = run(
+            sys.executable,
+            '-c',
+            'import sys; print("out"); sys.stderr.write("err\\n")',
+            split=False,
+            catch_output=True,
+            stdout_callback=stdout_lines.append,
+            stderr_callback=stderr_lines.append,
+        )
+
+    assert stdout_lines == ['out\n']
+    assert stderr_lines == ['err\n']
+    assert stdout_buffer.getvalue() == ''
+    assert stderr_buffer.getvalue() == ''
+    assert result.stdout == 'out\n'
+    assert result.stderr == 'err\n'
+
+
+def test_invalid_callbacks_are_rejected_before_process_or_threads_start():
+    """Invalid callback signatures are rejected before subprocess startup and reader thread creation."""
+    with patch.object(_run_module, 'Popen', side_effect=AssertionError('Popen should not be called')), \
+         patch.object(_run_module, 'Thread', side_effect=AssertionError('Thread should not be created')), \
+         pytest.raises(SignatureMismatchError, match='stdout_callback'):
+        run(sys.executable, '-c', 'print("hello")', split=False, stdout_callback=lambda: None)
+
+
+def test_invalid_callbacks_are_rejected_before_process_or_threads_start_with_catch_output():
+    """catch_output=True does not defer or skip callback validation."""
+    with patch.object(_run_module, 'Popen', side_effect=AssertionError('Popen should not be called')), \
+         patch.object(_run_module, 'Thread', side_effect=AssertionError('Thread should not be created')), \
+         pytest.raises(SignatureMismatchError, match='stderr_callback'):
+        run(sys.executable, '-c', 'print("hello")', split=False, catch_output=True, stderr_callback=lambda: None)
+
+
+def test_stdout_callback_validation_wins_when_both_callbacks_are_invalid():
+    """stdout_callback is validated first, so it determines the error when both callbacks are invalid."""
+    with pytest.raises(SignatureMismatchError, match='stdout_callback') as exc_info:
+        run(sys.executable, '-c', 'print("hello")', split=False, stdout_callback=lambda: None, stderr_callback=lambda: None)
+
+    assert 'stderr_callback' not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/units/test_run.py
+++ b/tests/units/test_run.py
@@ -14,7 +14,7 @@ from os import environ
 from pathlib import Path, PurePath
 from threading import Event, Thread
 from time import perf_counter
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 from typing import Any, List, cast
 from unittest.mock import patch
 
@@ -2557,6 +2557,18 @@ def test_check_output_stream_callback_rejects_invalid_callbacks(parameter_name, 
 
     assert parameter_name in str(exc_info.value)
     assert 'callback(line)' in str(exc_info.value)
+
+
+def test_check_output_stream_callback_skips_call_inspection_when_call_attribute_is_missing(monkeypatch):
+    """Runtime callback validation remains defensive if a callable's direct __call__ lookup is unavailable."""
+    def getattribute(value, name):
+        if name == '__call__':
+            raise AttributeError(name)
+        return object.__getattribute__(value, name)
+
+    monkeypatch.setattr(_run_module, 'object', SimpleNamespace(__getattribute__=getattribute), raising=False)
+
+    _run_module.check_output_stream_callback('stdout_callback', _valid_one_required_callback)
 
 
 class _InvalidCallableCallback:

--- a/tests/units/test_run_directory.py
+++ b/tests/units/test_run_directory.py
@@ -246,8 +246,8 @@ def test_directory_composes_with_stream_callbacks(tmp_path):
     assert Path(stderr_lines[0].rstrip('\n')).resolve() == directory.resolve()
 
 
-def test_directory_with_catch_output_bypasses_stream_callbacks(tmp_path):
-    """catch_output=True keeps bypassing callbacks when directory is set."""
+def test_directory_with_catch_output_still_calls_stream_callbacks(tmp_path):
+    """catch_output=True captures output without bypassing custom callbacks when directory is set."""
     directory = tmp_path / 'work'
     directory.mkdir()
     stdout_lines = []
@@ -267,8 +267,8 @@ def test_directory_with_catch_output_bypasses_stream_callbacks(tmp_path):
     assert result.returncode == 0
     assert result.stdout == 'stdout from child\n'
     assert result.stderr == 'stderr from child\n'
-    assert stdout_lines == []
-    assert stderr_lines == []
+    assert stdout_lines == ['stdout from child\n']
+    assert stderr_lines == ['stderr from child\n']
 
 
 def test_directory_composes_with_logger(tmp_path):


### PR DESCRIPTION
A minor change with no significant changes to the external API:

- Added validation of user-provided callbacks at an early stage, before they are actually invoked. If the callback signature does not match `suby's` expectations, an informative exception will be thrown.

- Updated some dependencies.